### PR TITLE
Add linear.style to add-ons section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Third-party add-ons to Linear to enhance Linear with more functionality.
 for teams on Linear
 - [LinearSync](https://linear-sync.com/) LinearSync sends GitHub issues to Linear. This lets open source maintainers better integrate community feedback into the Linear Method.
 - [Discord: Alerts](https://github.com/ezolla/linear-app-discord) Listener for Linear App new issue events connected to Discord.
+- [Linear.style](https://linear.style) A website to discover community-made Linear color themes
 
 ## Integrations
 


### PR DESCRIPTION
Hey 👋

I wasn't sure if "add-ons" was the best section for this to be honest, but it's probably the most fitting from the ones on there right now.

This is a website created by @alii and was promoted by Linear on Twitter once. It lets you discover color themes added by the community of Linear users.

Here is the repo behind it: https://github.com/alii/linear-style 