### PR TITLE
Remove Qualdesk

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,6 @@ Products that integrate with Linear.
 - [Reclaim.ai](https://reclaim.ai/) Smart time blocking for your calendar.
 - [Marker.io](https://marker.io/linear-website-issue-tracker) Make it easy for your team and clients to report website feedback into Linear, without driving developers crazy.
 - [Bird eats bug](https://birdeatsbug.com/) Create bug reports that developers love. Automatically.
-- [Qualdesk](https://qualdesk.com/) Work with your Linear issues in a flexible, multiplayer whiteboard environment. Any changes are automatically updated in Linear.
 - [Rootly](https://rootly.io) Manage incidents directly from Slack. Focus on what you do best, putting out 🔥.
 - [Highlight](https://www.highlight.run/) Collaborate fast with your team in resolving errors, UX pain points, and UI bugs.
  


### PR DESCRIPTION
Qualdesk is joining Miro and shutting down business end of February. See their statement on https://www.qualdesk.com